### PR TITLE
feat(portfolio): add project period rendering, dynamic design blueprint tabs, and figma links

### DIFF
--- a/src/components/Portfolio/ProjectDetailsPanel.css
+++ b/src/components/Portfolio/ProjectDetailsPanel.css
@@ -108,6 +108,50 @@
   margin: 0 0 var(--space-4) 0;
 }
 
+.ProjectDetailsPanel__period {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: var(--color-brand-orange-2);
+  font-weight: 500;
+  margin: 0 0 var(--space-3) 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ProjectDetailsPanel__tabs {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-2);
+}
+
+.ProjectDetailsPanel__tab-btn {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #aaa;
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: all var(--transition-fast, 0.2s ease);
+  flex: 1;
+  text-align: center;
+}
+
+.ProjectDetailsPanel__tab-btn:hover {
+  color: #fff;
+  border-color: rgba(255, 152, 0, 0.4);
+  background: rgba(255, 152, 0, 0.02);
+}
+
+.ProjectDetailsPanel__tab-btn.active {
+  background: var(--color-brand-orange-2);
+  border-color: var(--color-brand-orange-2);
+  color: #000;
+  font-weight: 600;
+}
+
 .ProjectDetailsPanel__divider {
   width: 100%;
   height: 1px;
@@ -266,4 +310,84 @@
   letter-spacing: 2px;
   line-height: 1;
   white-space: nowrap;
+}
+
+.ProjectDetailsPanel__architecture {
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.architecture-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+
+@media (min-width: 600px) {
+  .architecture-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.architecture-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: var(--space-4);
+  border-radius: 4px;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.architecture-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 152, 0, 0.4);
+  background: rgba(255, 152, 0, 0.02);
+}
+
+.architecture-card h5 {
+  margin: 0 0 var(--space-2) 0;
+  font-size: var(--font-size-base);
+  color: var(--color-brand-orange-2);
+  font-family: var(--font-display);
+  font-weight: 600;
+}
+
+.architecture-card p {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: #bbb;
+  line-height: 1.5;
+}
+
+.ProjectDetailsPanel__figjam-container {
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-6);
+  display: flex;
+}
+
+.ProjectDetailsPanel__figjam-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--color-brand-orange-2);
+  background-color: rgba(255, 152, 0, 0.03);
+  border: 1.5px dashed rgba(255, 152, 0, 0.35);
+  padding: var(--space-3) var(--space-6);
+  transition: all var(--transition-fast, 0.2s ease);
+  cursor: pointer;
+  width: 100%;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.ProjectDetailsPanel__figjam-btn:hover {
+  background-color: var(--color-brand-orange-2);
+  color: #000;
+  border-style: solid;
+  border-color: var(--color-brand-orange-2);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(255, 152, 0, 0.15);
 }

--- a/src/components/Portfolio/ProjectDetailsPanel.tsx
+++ b/src/components/Portfolio/ProjectDetailsPanel.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import type { ItemData } from "../../features/DetailSection/DetailSection";
 import { useLanguage } from "../../contexts/LanguageContext";
-import { getLocalizedProjectDesc, getLocalizedExperienceDesc, getLocalizedExperienceRole } from "../../data/projectTranslations";
+import { getLocalizedProjectDesc, getLocalizedExperienceDesc, getLocalizedExperienceRole, getLocalizedProjectPeriod } from "../../data/projectTranslations";
 import "./ProjectDetailsPanel.css";
 
 interface ProjectDetailsPanelProps {
@@ -14,6 +14,7 @@ interface ProjectDetailsPanelProps {
 export const ProjectDetailsPanel = ({ item, onClose, onOpenLightbox }: ProjectDetailsPanelProps) => {
   const { language, t } = useLanguage();
   const [isLightboxOpen, setIsLightboxOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<'details' | 'architecture'>('details');
 
   if (!item) return null;
 
@@ -78,24 +79,117 @@ export const ProjectDetailsPanel = ({ item, onClose, onOpenLightbox }: ProjectDe
           <h4 className="ProjectDetailsPanel__meta">{item.company}</h4>
         )}
 
+        {item.period && (
+          <div className="ProjectDetailsPanel__period">
+            {getLocalizedProjectPeriod(item.title || item.company || "", language, item.period)}
+          </div>
+        )}
+
+        {item.title === "Dog-bros (BroDogs)" && (
+          <div className="ProjectDetailsPanel__tabs">
+            <button 
+              className={`ProjectDetailsPanel__tab-btn ${activeTab === 'details' ? 'active' : ''}`}
+              onClick={() => setActiveTab('details')}
+            >
+              {language === "en" ? "Implementation & Tech" : "Implementación y Tech"}
+            </button>
+            <button 
+              className={`ProjectDetailsPanel__tab-btn ${activeTab === 'architecture' ? 'active' : ''}`}
+              onClick={() => setActiveTab('architecture')}
+            >
+              {language === "en" ? "Architecture Blueprint" : "Diseño de Arquitectura"}
+            </button>
+          </div>
+        )}
+
         <div className="ProjectDetailsPanel__divider"></div>
 
-        <p className="ProjectDetailsPanel__desc">{displayDesc}</p>
+        {activeTab === 'details' || item.title !== "Dog-bros (BroDogs)" ? (
+          <>
+            <p className="ProjectDetailsPanel__desc">{displayDesc}</p>
 
-        <h3 className="ProjectDetailsPanel__section-title">
-          {language === "en" ? "Technologies Used" : "Tecnologías Utilizadas"}
-        </h3>
-        <div className="ProjectDetailsPanel__tags">
-          {item.techStack.map(tech => (
-            <span key={tech} className="ProjectDetailsPanel__tag">{tech}</span>
-          ))}
-        </div>
+            <h3 className="ProjectDetailsPanel__section-title">
+              {language === "en" ? "Technologies Used" : "Tecnologías Utilizadas"}
+            </h3>
+            <div className="ProjectDetailsPanel__tags">
+              {item.techStack.map(tech => (
+                <span key={tech} className="ProjectDetailsPanel__tag">{tech}</span>
+              ))}
+            </div>
 
-        {item.link && (
-          <div className="ProjectDetailsPanel__actions">
-            <a href={item.link} target="_blank" rel="noopener noreferrer" className="ProjectDetailsPanel__link-btn">
-              {t("portfolio.viewProject")}
-            </a>
+            {item.link && (
+              <div className="ProjectDetailsPanel__actions">
+                <a href={item.link} target="_blank" rel="noopener noreferrer" className="ProjectDetailsPanel__link-btn">
+                  {t("portfolio.viewProject")}
+                </a>
+                {item.company === "Cacao-Cocoa (RaukeIT)" && (
+                  <a 
+                    href="https://www.figma.com/design/7WwOrwfeQWIM29lMRMla73/Cacao?m=auto&t=HgMFoQ407ffaGWWZ-1" 
+                    target="_blank" 
+                    rel="noopener noreferrer" 
+                    className="ProjectDetailsPanel__figjam-btn"
+                    style={{ marginTop: 'var(--space-2)' }}
+                  >
+                    🎨 {language === "en" ? "Figma Design" : "Diseño en Figma"}
+                  </a>
+                )}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="ProjectDetailsPanel__architecture">
+            <h3 className="ProjectDetailsPanel__section-title">
+              {language === "en" ? "System Design Blueprint" : "Plan de Arquitectura de Producción"}
+            </h3>
+            <p className="ProjectDetailsPanel__desc">
+              {language === "en"
+                ? "This blueprint maps the physical dark kitchen operations directly to software engineering patterns, outlining a production-ready architecture design and proactive risk mitigation strategies (not implemented in the current live frontend MVP)."
+                : "Este plano mapea las operaciones físicas de la dark kitchen directamente con patrones de ingeniería de software, detallando una propuesta de arquitectura de producción y mitigación de riesgos (no implementados en el MVP actual de solo frontend)."}
+            </p>
+            <div className="architecture-grid">
+              <div className="architecture-card">
+                <h5>🛡️ {language === "en" ? "Early Payload Validation" : "Validación Temprana de Payload"}</h5>
+                <p>
+                  {language === "en" 
+                    ? "Prevents 'last-mile' delivery failures by validating complete transaction details (payment method, bill denomination, exact address) at the client level before pushing to the core queue."
+                    : "Previene fallos en la 'última milla' validando los detalles completos de la orden (método de pago, denominación del billete, dirección exacta) en el cliente antes de ingresarla a la cola del sistema."}
+                </p>
+              </div>
+              <div className="architecture-card">
+                <h5>🔄 {language === "en" ? "Asynchronous Decoupling" : "Desacoplamiento Asíncrono"}</h5>
+                <p>
+                  {language === "en"
+                    ? "Kitchen preparation and courier dispatch operate as independent microservices. Cougars listen for the 'ORDER_READY' event, eliminating main-thread blocking and sync dependencies."
+                    : "La preparación en cocina y el despacho de repartidores operan como microservicios desacoplados. Las motos escuchan el evento asíncrono 'ORDER_READY', eliminando bloqueos y dependencias síncronas."}
+                </p>
+              </div>
+              <div className="architecture-card">
+                <h5>⏱️ {language === "en" ? "Retention Async Timer" : "Timer Asíncrono de Retención"}</h5>
+                <p>
+                  {language === "en"
+                    ? "A custom retention alarm (40-70 mins post-delivery) automates proactive QA. Captures high-value customer feedback for social proof (Instagram) or mitigates cold-delivery complaints offline."
+                    : "Un temporizador automático (40-70 mins post-entrega) gatilla un QA proactivo. Captura reseñas de alto valor para marketing o contiene quejas por comida fría de forma offline antes de que lleguen a redes."}
+                </p>
+              </div>
+              <div className="architecture-card">
+                <h5>🚦 {language === "en" ? "Priority Queue (Jiutepec)" : "Cola de Prioridades (Jiutepec)"}</h5>
+                <p>
+                  {language === "en"
+                    ? "Location-based routing algorithm. Orders from the immediate local zone (Jiutepec) are dynamically tagged as HIGH_PRIORITY to minimize overhead and maximize delivery turnaround."
+                    : "Algoritmo de ruteo por geocercanía. Los pedidos de la zona local inmediata (Jiutepec) se etiquetan dinámicamente con ALTA_PRIORIDAD para reducir costos logísticos y acelerar los despachos."}
+                </p>
+              </div>
+            </div>
+            <div className="ProjectDetailsPanel__figjam-container" style={{ marginTop: 'var(--space-6)' }}>
+              <a 
+                href="https://www.figma.com/board/pQMpB4D8A26F9nYB0CG2gb/SamBurger?node-id=0-1&p=f&t=HgMFoQ407ffaGWWZ-0" 
+                target="_blank" 
+                rel="noopener noreferrer" 
+                className="ProjectDetailsPanel__figjam-btn"
+              >
+                🎨 {language === "en" ? "View Full Interactive FigJam Board" : "Ver Diagrama Completo en FigJam"}
+              </a>
+            </div>
           </div>
         )}
       </div>

--- a/src/data/projectTranslations.ts
+++ b/src/data/projectTranslations.ts
@@ -111,19 +111,17 @@ export function getLocalizedProjectPeriod(title: string, lang: string, fallback:
   if (trans && trans.period) {
     return lang === "en" ? trans.period.en : trans.period.es;
   }
-  // Traducir dinámicamente si dice "Actualidad" o similares
-  if (fallback.includes("Actualidad") && lang === "en") {
-    return fallback.replace("Actualidad", "Present");
-  }
-  if (fallback.includes("Actualidad") && lang === "es") {
-    return fallback;
-  }
-  if (fallback.includes("[COMPLETAR]") && lang === "en") {
-    return "[TO COMPLETE]";
-  }
-  // Traducir nombres de meses
+  
   let result = fallback;
+  
   if (lang === "en") {
+    if (result.includes("Actualidad")) {
+      result = result.replace("Actualidad", "Present");
+    }
+    if (result.includes("[COMPLETAR]")) {
+      result = result.replace("[COMPLETAR]", "TO COMPLETE");
+    }
+    
     const months = {
       "Enero": "January", "Febrero": "February", "Marzo": "March", "Abril": "April",
       "Mayo": "May", "Junio": "June", "Julio": "July", "Agosto": "August",
@@ -133,6 +131,7 @@ export function getLocalizedProjectPeriod(title: string, lang: string, fallback:
       result = result.replace(esMonth, enMonth);
     }
   }
+  
   return result;
 }
 

--- a/src/features/DetailSection/DetailSection.css
+++ b/src/features/DetailSection/DetailSection.css
@@ -142,6 +142,17 @@
   white-space: nowrap;
 }
 
+.ProjectCard__period-tag {
+  font-size: var(--font-size-xs);
+  color: #ff9800;
+  opacity: 0.85;
+  margin-bottom: var(--space-1);
+  display: block;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .ProjectCard__title {
   font-size: var(--font-size-2lg);
   margin: 0 0 var(--space-3) 0;

--- a/src/features/DetailSection/DetailSection.tsx
+++ b/src/features/DetailSection/DetailSection.tsx
@@ -4,7 +4,8 @@ import { useLanguage } from "../../contexts/LanguageContext";
 import {
   getLocalizedProjectDesc,
   getLocalizedExperienceRole,
-  getLocalizedExperienceDesc
+  getLocalizedExperienceDesc,
+  getLocalizedProjectPeriod
 } from "../../data/projectTranslations";
 
 type IconComponent = React.FC<React.SVGProps<SVGSVGElement>>;
@@ -17,6 +18,7 @@ export interface ItemData {
   techStack: string[];
   image?: string;
   link?: string;
+  period?: string;
 }
 
 interface DetailSectionProps {
@@ -82,6 +84,10 @@ const DetailSection = ({ title, description, items, icons, backgroundImg, backgr
             (!isProject && selectedItem.company === item.company)
           );
 
+          const displayPeriod = item.period
+            ? getLocalizedProjectPeriod(item.title || item.company || "", language, item.period)
+            : "";
+
           return (
             <article 
               key={index} 
@@ -104,6 +110,9 @@ const DetailSection = ({ title, description, items, icons, backgroundImg, backgr
               />
 
               <div className="ProjectCard__content">
+                {displayPeriod && (
+                  <span className="ProjectCard__period-tag">{displayPeriod}</span>
+                )}
                 <h3 className="ProjectCard__title">
                   {item.title || `${displayRole} ${language === "en" ? "at" : "en"} ${item.company}`}
                 </h3>
@@ -124,6 +133,25 @@ const DetailSection = ({ title, description, items, icons, backgroundImg, backgr
                     onClick={(e) => e.stopPropagation()}
                   >
                     {t("portfolio.viewProject")}
+                  </a>
+                )}
+
+                {item.company === "Cacao-Cocoa (RaukeIT)" && (
+                  <a 
+                    href="https://www.figma.com/design/7WwOrwfeQWIM29lMRMla73/Cacao?m=auto&t=HgMFoQ407ffaGWWZ-1" 
+                    target="_blank" 
+                    rel="noopener noreferrer" 
+                    className="ProjectCard__link"
+                    style={{ 
+                      marginTop: 'var(--space-2)', 
+                      border: '1px dashed var(--color-brand-orange-2)', 
+                      color: 'var(--color-brand-orange-2)', 
+                      backgroundColor: 'transparent',
+                      textAlign: 'center'
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    🎨 {language === "en" ? "Figma Design" : "Diseño en Figma"}
                   </a>
                 )}
               </div>


### PR DESCRIPTION
### Summary
- **Project & Experience Periods**: Added period tags/badges above titles in both ProjectCards and the ProjectDetailsPanel.
- **Dog-bros Interactive Blueprint**: Introduced a dynamic tab selector ("Implementación y Tech" / "Diseño de Arquitectura") inside ProjectDetailsPanel to explicitly outline his production-ready architectural proposal and risk-mitigation plans with complete transparency.
- **Figma Designs Integration**: Embedded direct visual links to FigJam canvas blueprints and original Figma UI/UX designs for both `Dog-bros (BroDogs)` and `Cacao-Cocoa`.
- **Localization Bugfix**: Fixed a short-circuit bug in `getLocalizedProjectPeriod` that prevented Spanish month names from translating in the English locale when period contained the term "Actualidad".

### Changes Table
| File | Change |
|------|--------|
| `src/data/projectTranslations.ts` | Fix short-circuit period localization bug |
| `src/features/DetailSection/DetailSection.tsx` | Extend `ItemData` interface and render dynamic period tags |
| `src/features/DetailSection/DetailSection.css` | Styled the `.ProjectCard__period-tag` |
| `src/components/Portfolio/ProjectDetailsPanel.tsx` | Add activeTab state, render tab triggers, and embed Figma links |
| `src/components/Portfolio/ProjectDetailsPanel.css` | Styled tab triggers, architecture grid, cards, and dashed Figma links |

### Test Plan
- [x] Run production build (`pnpm run build`) successfully with 0 errors.
- [x] Verified localized translation logic for both Spanish and English locales.
- [x] Checked responsive bottom-sheet modal layouts on multiple device sizes.
