### PR TITLE
fix(deploy): enable cleanUrls so Vercel serves prerendered per-route HTML

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "cleanUrls": true,
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
   ],


### PR DESCRIPTION
## Problem (found in production)

After PR #12 deployed, every clean URL on franguh.plynte.com still served the **homepage** HTML:

| URL | Served title | Should be |
|-----|--------------|-----------|
| `/about` | `Inicio \| ...` | `Sobre Mí \| ...` |
| `/portfolio/voiceai-kira` | `Inicio \| ...` | `VoiceAI Kira \| ...` |

The prerendered files are correct and deployed — `/about.html` and `/portfolio/voiceai-kira.html` serve the right per-route `<title>`/canonical/OG. They were just unreachable via the clean URLs that crawlers and users actually request.

## Root cause

`vercel.json` keeps the SPA catch-all rewrite `/(.*) → /index.html`. Without `cleanUrls`, a request to `/about` does **not** match the on-disk file `about.html`, so it falls through to the rewrite and gets `index.html`. The whole point of the prerender (per-route meta for SEO/GEO) was therefore dead in production.

## Fix

Add `"cleanUrls": true`. Vercel then serves `about.html` at `/about` (filesystem match takes precedence over rewrites), so:

- known routes → their own prerendered HTML ✅
- unknown slugs (no file) → catch-all rewrite → `index.html` → SPA renders `NotFoundPage` ✅

One line, no build change.

## Verification

- [x] Confirmed in prod that `/about.html` + `/portfolio/voiceai-kira.html` already serve correct per-route meta (files deployed fine)
- [x] Confirmed clean URLs (`/about`, `/portfolio/:slug`) currently serve homepage meta (the bug)
- [ ] After deploy: re-fetch `/about` and a slug, confirm per-route `<title>`/canonical/OG

## Notes
- Conventional commit, no `Co-Authored-By`.
- Out of scope (tracked separately): HSTS is already injected upstream but lacks `includeSubDomains; preload`.