### PR TITLE
fix(seo): serve branded 404.html with real 404 status

### DIFF
--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -45,6 +45,14 @@ export const routes: RouteRecord[] = [
         getStaticPaths: () => portfolioSlugs.map((slug) => `portfolio/${slug}`),
       },
       {
+        // Concrete /404 route so vite-react-ssg emits a prerendered dist/404.html.
+        // Vercel serves this file with a real HTTP 404 for any unmatched path.
+        path: "404",
+        lazy: lazyDefault(() => import("../pages/NotFoundPage/NotFoundPage")),
+      },
+      {
+        // Client-side fallback: in-app navigation to an unknown route still
+        // renders NotFoundPage without a full server round-trip.
         path: "*",
         lazy: lazyDefault(() => import("../pages/NotFoundPage/NotFoundPage")),
       },

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,5 @@
 {
   "cleanUrls": true,
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
-  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## What
Serve the branded NotFoundPage with a real HTTP 404 status for unknown URLs (closes audit **SEO-3**, soft-404).

## Changes
- Add a concrete `404` route in `AppRouter.tsx` so `vite-react-ssg` prerenders `dist/404.html` (the `*` route stays for client-side fallback).
- Remove the catch-all SPA rewrite from `vercel.json`. With every route prerendered + `cleanUrls`, Vercel serves `/404.html` with a real 404 for any unmatched path.

## Verified
- Build emits `dist/404.html` (NotFoundPage body, own `<title>`, `robots: noindex, nofollow`).
- All 17 known routes still emit; lint + build clean.

## Needs post-deploy verification (Vercel preview)
- `/portfolio/no-existe` → **HTTP 404** + branded page (not Vercel's default).
- Known routes still 200; in-app navigation to a bad route still renders NotFoundPage.

## Note
Removing the catch-all rewrite means any future *client-only* route would 404 on direct load. None exist today (all prerendered); re-add a fallback only if one is introduced.
