### PR TITLE
fix(security): add honeypot and send cooldown to contact form

### DIFF
--- a/src/components/Contacto/ContactForm.css
+++ b/src/components/Contacto/ContactForm.css
@@ -26,6 +26,17 @@
     border: 1px solid var(--color-dark-border);
 }
 
+/* Honeypot: kept in the DOM but pulled off-screen so humans never see or tab
+   into it, while bots that auto-fill every field still trip it. Avoid
+   display:none — some bots skip non-rendered fields. */
+.ContactForm__hp {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
 .ContactForm__input-group {
     display: flex;
     flex-direction: column;

--- a/src/components/Contacto/ContactForm.tsx
+++ b/src/components/Contacto/ContactForm.tsx
@@ -1,13 +1,30 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import emailjs from '@emailjs/browser';
 import './ContactForm.css';
 import Button from '../UI/Button/Button';
 import { useLanguage } from '../../contexts/LanguageContext';
 
+// Minimum gap between two successful sends from the same browser session.
+// Client-side throttle only — server-side abuse must be stopped in the EmailJS
+// dashboard (captcha + per-IP rate limit + allowed origins).
+const COOLDOWN_MS = 30_000;
+
 export default function ContactForm() {
   const [formData, setFormData] = useState({ name: '', email: '', message: '' });
-  const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error' | 'invalid'>('idle');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error' | 'invalid' | 'cooldown'>('idle');
+  const honeypotRef = useRef<HTMLInputElement>(null);
+  const [onCooldown, setOnCooldown] = useState(false);
+  const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { t } = useLanguage();
+
+  useEffect(() => () => {
+    if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+  }, []);
+
+  const startCooldown = () => {
+    setOnCooldown(true);
+    cooldownTimer.current = setTimeout(() => setOnCooldown(false), COOLDOWN_MS);
+  };
 
   const isEmailConfigured = Boolean(
     import.meta.env.VITE_EMAILJS_SERVICE_ID &&
@@ -35,13 +52,27 @@ export default function ContactForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
+    // Honeypot: a real user never sees this field. If it has a value, a bot
+    // filled it — feign success and drop the submission without sending.
+    if (honeypotRef.current?.value) {
+      setStatus('success');
+      setFormData({ name: '', email: '', message: '' });
+      return;
+    }
+
+    if (onCooldown) {
+      setStatus('cooldown');
+      return;
+    }
+
     if (!isEmailConfigured) {
       setStatus('error');
       return;
     }
 
     if (!formData.name || !formData.email || !formData.message) return;
-    
+
     if (!validateInput(formData.name) || !validateInput(formData.message)) {
       setStatus('invalid');
       return;
@@ -63,6 +94,7 @@ export default function ContactForm() {
     .then(() => {
       setStatus('success');
       setFormData({ name: '', email: '', message: '' });
+      startCooldown();
     })
     .catch((error) => {
       if (import.meta.env.DEV) {
@@ -79,6 +111,19 @@ export default function ContactForm() {
       <p className="ContactForm__subtitle">{t("contact.description")}</p>
       
       <form onSubmit={handleSubmit} className="ContactForm__form">
+        {/* Honeypot: visually hidden and skipped by keyboard/AT; only bots fill it. */}
+        <div className="ContactForm__hp" aria-hidden="true">
+          <label htmlFor="website">Leave this field empty</label>
+          <input
+            type="text"
+            id="website"
+            name="website"
+            ref={honeypotRef}
+            tabIndex={-1}
+            autoComplete="off"
+          />
+        </div>
+
         <div className="ContactForm__input-group">
           <label htmlFor="name">{t("contact.nameLabel")}</label>
           <input
@@ -142,12 +187,13 @@ export default function ContactForm() {
         <div role="alert" aria-live="assertive">
           {!isEmailConfigured && <p className="ContactForm__feedback error">{t("contact.errorEmail")}</p>}
           {status === 'invalid' && <p className="ContactForm__feedback error">{t("contact.errorFields")}</p>}
+          {status === 'cooldown' && <p className="ContactForm__feedback error">{t("contact.cooldown")}</p>}
           {status === 'error' && isEmailConfigured && <p className="ContactForm__feedback error">{t("contact.error")}</p>}
           {status === 'success' && <p className="ContactForm__feedback success">{t("contact.success")}</p>}
         </div>
         
         <div style={{ alignSelf: 'center', marginTop: "var(--space-2)" }}>
-          <Button type="submit" disabled={status === 'sending' || !isEmailConfigured} isLoading={status === 'sending'}>
+          <Button type="submit" disabled={status === 'sending' || !isEmailConfigured || onCooldown} isLoading={status === 'sending'}>
             {status === 'sending' ? t("contact.buttonSending") : t("contact.buttonSend")}
           </Button>
         </div>

--- a/src/data/translations.ts
+++ b/src/data/translations.ts
@@ -128,7 +128,8 @@ export const translations: Record<"es" | "en", TranslationTree> = {
       success: "¡Mensaje enviado con éxito!",
       error: "Ocurrió un error al enviar. Intenta de nuevo más tarde.",
       errorFields: "Caracteres inválidos detectados. Solo utiliza texto estándar.",
-      errorEmail: "El formulario no está configurado todavía. Usa LinkedIn o GitHub para contactarme."
+      errorEmail: "El formulario no está configurado todavía. Usa LinkedIn o GitHub para contactarme.",
+      cooldown: "Acabás de enviar un mensaje. Esperá unos segundos antes de mandar otro."
     },
     portfolio: {
       eyebrow: "Portafolio",
@@ -286,7 +287,8 @@ export const translations: Record<"es" | "en", TranslationTree> = {
       success: "Message sent successfully!",
       error: "An error occurred while sending. Please try again later.",
       errorFields: "Invalid characters detected. Please use standard text only.",
-      errorEmail: "The form is not configured yet. Use LinkedIn or GitHub to contact me."
+      errorEmail: "The form is not configured yet. Use LinkedIn or GitHub to contact me.",
+      cooldown: "You just sent a message. Please wait a few seconds before sending another."
     },
     portfolio: {
       eyebrow: "Portfolio",


### PR DESCRIPTION
## What
Add client-side anti-abuse to the contact form (partial fix for audit **SECU-1**).

## Changes
- **Honeypot**: hidden `website` field (off-screen, `aria-hidden` + `tabIndex=-1`), read via ref on submit. If filled, feign success and drop without sending. Never enters the EmailJS payload.
- **Cooldown**: 30s lock after a successful send — blocks resubmits, disables the button, shows a message (new `contact.cooldown` i18n key, ES + EN).

## Verified
- Lint + build clean. Honeypot value never reaches `emailjs.send`. Cooldown timer cleared on unmount.

## ⚠️ Server-side half still required (only the maintainer can do this)
EmailJS service/template/public keys ship in the bundle by design, so a bot POSTing directly to `api.emailjs.com` bypasses ALL client defenses. This PR is mitigation, not the full fix. In the EmailJS dashboard:
1. Enable captcha (reCAPTCHA).
2. Per-IP / per-domain rate limit.
3. Restrict allowed origins to `franguh.plynte.com`.

SECU-1 is not fully closed until those are enabled.
