### PR TITLE
fix(geo): generate JSON-LD @graph from cvData so it covers all work

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,71 +14,12 @@
     -->
     <link rel="icon" type="image/svg+xml" href="/Plynte.svg" />
 
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@graph": [
-          {
-            "@type": "Person",
-            "@id": "https://franguh.plynte.com/#person",
-            "name": "Gustavo Francisco Salgado Andrade",
-            "jobTitle": "Ingeniero en Sistemas Computacionales | Full-Stack",
-            "url": "https://franguh.plynte.com/",
-            "sameAs": [
-              "https://linkedin.com/in/gustavo-francisco-salgado-andrade-496553337",
-              "https://github.com/FranGuh"
-            ]
-          },
-          {
-            "@type": "WebSite",
-            "@id": "https://franguh.plynte.com/#website",
-            "name": "FranGuh Portfolio",
-            "url": "https://franguh.plynte.com/",
-            "publisher": { "@id": "https://franguh.plynte.com/#person" },
-            "inLanguage": ["es", "en"]
-          },
-          {
-            "@type": "SoftwareApplication",
-            "name": "Brick.draw",
-            "applicationCategory": "DesignApplication",
-            "operatingSystem": "Desktop",
-            "description": "Software de escritorio de uso ligero para uso creativo, inspirado en Paint y Photoshop, con integración al servicio local Sloppy para mejorar dibujos usando Stable Diffusion XL.",
-            "author": { "@id": "https://franguh.plynte.com/#person" }
-          },
-          {
-            "@type": "WebApplication",
-            "name": "Dog-bros (BroDogs)",
-            "applicationCategory": "BusinessApplication",
-            "description": "Sistema web para previsualizar el menú de una dark kitchen y calcular pedidos.",
-            "url": "https://san-burgus.vercel.app/",
-            "author": { "@id": "https://franguh.plynte.com/#person" }
-          },
-          {
-            "@type": "SoftwareApplication",
-            "name": "Floppy",
-            "applicationCategory": "DeveloperApplication",
-            "operatingSystem": "Any",
-            "description": "Pipeline automatizado de visión artificial para procesamiento masivo de datos y gestión de VRAM utilizando Python, DBSCAN y CUDA.",
-            "author": { "@id": "https://franguh.plynte.com/#person" }
-          },
-          {
-            "@type": "WebApplication",
-            "name": "Plynte",
-            "applicationCategory": "WebApplication",
-            "description": "Sistema web para gestionar tráfico y visualizar estadísticas del sitio mediante Cloudflare.",
-            "url": "https://franguh.plynte.com/",
-            "author": { "@id": "https://franguh.plynte.com/#person" }
-          },
-          {
-            "@type": "SoftwareApplication",
-            "name": "Sloppy",
-            "applicationCategory": "DeveloperApplication",
-            "description": "API de visión artificial para la generación de imágenes utilizando modelos de Stable Diffusion XL, se conecta con Brick.draw para mejorar dibujos mediante inferencia local.",
-            "author": { "@id": "https://franguh.plynte.com/#person" }
-          }
-        ]
-      }
-    </script>
+    <!--
+      The site-wide JSON-LD knowledge @graph is generated from src/data/cvData.ts
+      and injected here at build time by the `portfolio-structured-data` Vite
+      plugin (see vite.config.ts), so it always covers every project/experience
+      and can never drift. Do not hand-write structured data in this file.
+    -->
   </head>
   <body>
     <div id="root"></div>

--- a/src/data/structuredData.ts
+++ b/src/data/structuredData.ts
@@ -1,0 +1,66 @@
+// src/data/structuredData.ts
+// Single source of truth for the site-wide JSON-LD knowledge @graph.
+// Generated from cvData so the structured data can never drift out of sync
+// with the real project / experience list (audit GEO-2). The Vite plugin in
+// vite.config.ts injects the output into every prerendered page's <head>.
+import { cvData } from "./cvData";
+import { generateSlug } from "../utils/slug";
+import { SITE_NAME, SITE_URL } from "../utils/site";
+
+type GraphNode = Record<string, unknown>;
+
+const PERSON_ID = `${SITE_URL}/#person`;
+
+const detailUrl = (value: string) => `${SITE_URL}/portfolio/${generateSlug(value)}`;
+
+const personNode: GraphNode = {
+  "@type": "Person",
+  "@id": PERSON_ID,
+  name: cvData.profile.name,
+  jobTitle: cvData.profile.subtitle,
+  url: `${SITE_URL}/`,
+  sameAs: [
+    "https://www.linkedin.com/in/gustavo-francisco-salgado-andrade-496553337",
+    "https://github.com/FranGuh",
+  ],
+};
+
+const websiteNode: GraphNode = {
+  "@type": "WebSite",
+  "@id": `${SITE_URL}/#website`,
+  name: SITE_NAME,
+  url: `${SITE_URL}/`,
+  publisher: { "@id": PERSON_ID },
+  inLanguage: ["es", "en"],
+};
+
+// A deployed project links to its live app; everything else points at its
+// prerendered detail page so every entry exposes a resolvable URL.
+const projectNodes: GraphNode[] = cvData.projects.map((project) => ({
+  "@type": project.link ? "WebApplication" : "SoftwareApplication",
+  name: project.title,
+  description: project.description,
+  url: project.link ?? detailUrl(project.title),
+  ...(project.link ? { sameAs: detailUrl(project.title) } : {}),
+  keywords: project.techStack.join(", "),
+  author: { "@id": PERSON_ID },
+}));
+
+// Experience roles are modelled as the web product built during the role: the
+// company is the product name and the role is carried in the description.
+const experienceNodes: GraphNode[] = cvData.experience.map((experience) => ({
+  "@type": experience.link ? "WebApplication" : "SoftwareApplication",
+  name: experience.company,
+  description: `${experience.role} — ${experience.description}`,
+  url: experience.link ?? detailUrl(experience.role),
+  ...(experience.link ? { sameAs: detailUrl(experience.role) } : {}),
+  keywords: experience.techStack.join(", "),
+  author: { "@id": PERSON_ID },
+}));
+
+export const buildPortfolioGraph = () => ({
+  "@context": "https://schema.org",
+  "@graph": [personNode, websiteNode, ...projectNodes, ...experienceNodes],
+});
+
+export const portfolioJsonLd = () => JSON.stringify(buildPortfolioGraph());

--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -7,6 +7,9 @@ export const toAbsoluteUrl = (path = '/') => {
     return path;
   }
 
+  // Plain concatenation (SITE_URL has no trailing slash, path is rooted) keeps
+  // this util free of the `URL` runtime global so it can be imported from
+  // build-time / node code as well as the browser.
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  return new URL(normalizedPath, SITE_URL).toString();
+  return `${SITE_URL}${normalizedPath}`;
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,26 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import { portfolioJsonLd } from './src/data/structuredData'
+
+// Injects the site-wide JSON-LD @graph (generated from cvData) into the head of
+// the built index.html, which vite-react-ssg then reuses as the template for
+// every prerendered page. Keeps structured data in one route-invariant place
+// and sourced from a single source of truth (audit GEO-2).
+const structuredData = () => ({
+  name: 'portfolio-structured-data',
+  transformIndexHtml: () => [
+    {
+      tag: 'script',
+      attrs: { type: 'application/ld+json' },
+      children: portfolioJsonLd(),
+      injectTo: 'head' as const,
+    },
+  ],
+})
 
 // https://vite.dev/config/
 export default defineConfig(({ isSsrBuild }) => ({
-  plugins: [react()],
+  plugins: [react(), structuredData()],
   build: {
     // The SSR/SSG pass externalizes React, so manualChunks must only run for
     // the client build (audit PERF-1: isolate the stable React/runtime vendor


### PR DESCRIPTION
## What
Generate the site-wide JSON-LD `@graph` from `cvData` so it covers all work and can never drift (closes audit **GEO-2**).

## Problem
The hand-written `@graph` in `index.html` listed only **5 of 12** projects and **no** experience roles — AI crawlers (ChatGPT/Claude/Perplexity) saw an incomplete profile.

## Changes
- New `src/data/structuredData.ts` builds the graph from `cvData`: Person + WebSite + all 12 projects + 2 experiences (**16 nodes**).
- Vite `transformIndexHtml` plugin injects the JSON-LD into the built `index.html` head, which `vite-react-ssg` reuses as the template for all 18 prerendered pages.
- Removed the hand-written block from `index.html` (single source of truth = `cvData`; never drifts again).
- `toAbsoluteUrl` no longer uses the `URL` global so the generator is importable from build-time/node code (this was the root cause of a `tsc` node-project type error).

## Modeling
Each project → `WebApplication` if it has a live link, else `SoftwareApplication`; `url` = live link or its prerendered `/portfolio/:slug` page; `keywords` = tech stack; `author` = Person `@id`. Experiences modelled the same way (company as name, role in description).

## Verified
- Output is valid JSON (`JSON.parse` OK), 16 nodes, propagates to `about.html` + slug pages. Lint + build clean.

## Needs post-deploy verification
- Rich Results / schema validator on the deployed URL to confirm Google/AI crawlers parse the enriched graph.
