### PR TITLE
fix(csp): allow inline scripts so the prerendered app can hydrate

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.emailjs.com; frame-src 'none'; object-src 'none'; base-uri 'self'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://api.emailjs.com; frame-src 'none'; object-src 'none'; base-uri 'self'"
         }
       ]
     }


### PR DESCRIPTION
## 🔴 Production hotfix — site is down in-browser

`franguh.plynte.com` throws **"Unexpected Application Error! Unexpected token '<' … is not valid JSON"** and the navbar/megamenu never mount.

## Root cause (confirmed against the built output)
`vite-react-ssg` injects **first-party inline scripts** into every prerendered page:
- `window.__VITE_REACT_SSG_HASH__ = '<hash>'` — the loader-data manifest hash
- `window.__staticRouterHydrationData = …` — react-router hydration state
- React resume runtime (`$RB/$RV`) on streamed pages

The strict `script-src 'self'` CSP **blocked all of them**. With the hash script blocked, `__VITE_REACT_SSG_HASH__` is `undefined`, so the client fetches `/static-loader-data-manifest-undefined.json` → 404 → returns HTML → `JSON.parse('<!DOCTYPE …')` throws → the app never hydrates → navbar/megamenu/routing are dead.

Verified: `dist/static-loader-data-manifest-<hash>.json` exists with the exact hash in the inline script, so the only failure is the CSP block.

This is a **pre-existing conflict** between the CSP (audit/SECU work) and the prerender (PR #12), latent because earlier verification checked served HTML/meta, not the running browser app. Not caused by the SEO/SECU/GEO merges.

## Fix
Add `'unsafe-inline'` to `script-src`. Every other CSP directive is unchanged (`default-src`, `connect-src`, `img-src`, `frame-src`, `object-src`, `base-uri`, plus the existing `style-src 'unsafe-inline'`).

## Tradeoff
For a static prerendered site with no server-side reflection of user input, the real XSS surface is low. The strict alternative (per-request nonces via Vercel middleware that rewrites the static HTML) defeats static caching and is overkill for a portfolio. Documented for the future if full strict CSP is ever wanted.

## Verification (post-deploy, on the preview)
- Home + `/portfolio` hydrate; navbar/megamenu work.
- No CSP errors in console; no `…-undefined.json` request.
