### PR TITLE
fix(404): defer pathname render to client to avoid hydration mismatch

### DIFF
--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Button from "../../components/UI/Button/Button";
 import "./NotFoundPage.css";
@@ -10,7 +11,13 @@ const NotFoundPage = () => {
   const navigate = useNavigate();
   const { t } = useLanguage();
 
-  const pathname = location.pathname;
+  // This page is served from a single statically prerendered 404.html (built at
+  // /404), but the visitor's real path varies. Rendering location.pathname on
+  // the first pass would mismatch the baked "/404" and break hydration (React
+  // #418), so only show the path after the component has mounted on the client.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const urlInfoParts = t("notFound.urlInfo").split("{path}");
 
   return (
@@ -28,7 +35,7 @@ const NotFoundPage = () => {
 
       <div className="Page404__content">
         <p>
-          {urlInfoParts[0]}<code>{pathname}</code>{urlInfoParts[1]}
+          {urlInfoParts[0]}{mounted && <code>{location.pathname}</code>}{urlInfoParts[1]}
         </p>
         <p>
           {t("notFound.subInfo")}


### PR DESCRIPTION
## What
Fix a React hydration error (#418) on the 404 page, surfaced by visiting any unknown URL (e.g. `/portfolio/log`).

## Root cause
SEO-3 prerenders a single `dist/404.html` built at the `/404` route, so `location.pathname` is baked as `/404`. Vercel serves that same file for every unknown URL. On the client, `NotFoundPage` re-renders `location.pathname` as the real path (`/portfolio/log`), so the `<code>` text no longer matches the server HTML → **React #418 hydration mismatch**.

(The HTTP **404 status itself is correct and expected** — that's SEO-3 working. Only the hydration error is the bug.)

## Fix
Gate the pathname behind a `mounted` flag (set in `useEffect`). Server render and the first client render both omit the `<code>` (they match → no mismatch); after mount the real path is shown.

## Verified
- Lint + build clean. Static `dist/404.html` no longer bakes a path; the 404 message still renders. Server/first-client render now identical.

## Post-deploy check
- Visit an unknown URL → branded 404, **no React #418 in console**, and the real path appears once hydrated.
